### PR TITLE
All restart of hash command and skip files previously hashed

### DIFF
--- a/deduplify/cli.py
+++ b/deduplify/cli.py
@@ -83,6 +83,11 @@ def parse_args(args):
         default="uniques.json",
         help="Destination file for unique hashes. Must be a JSON file. Default: uniques.json",
     )
+    parser_hash.add_argument(
+        "--restart",
+        action="store_true",
+        help="Restart a run of hashing files and skip over files that have already been hashed. Output files containing duplicated and unique filenames must already exist.",
+    )
 
     # Compare subcommand
     parser_compare = subparsers.add_parser(


### PR DESCRIPTION
<!-- Please complete the following sections when you submit your pull request.
You are encouraged to keep this top level comment box updated as you develop and respond to reviews.
Note that text within html comment tags will not be rendered. -->
### Summary
<!-- Describe the problem you're trying to fix in this pull request.
Please reference any related issue and use fixes/close to automatically close them, if pertinent.
For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This PR introduced a `--restart` flag to `deduplify hash`. This is so that the hash process can be restarted and will skip over files listed in the unique and deduplicated files outputs.

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?
