### PR TITLE
Fix a bug that would delete files that should be investigated

### DIFF
--- a/deduplify/_version.py
+++ b/deduplify/_version.py
@@ -7,5 +7,5 @@ Provides deduplify version information.
 
 from incremental import Version
 
-__version__ = Version("deduplify", 0, 4, 1)
+__version__ = Version("deduplify", 0, 4, 2)
 __all__ = ["__version__"]

--- a/deduplify/compare_files.py
+++ b/deduplify/compare_files.py
@@ -72,10 +72,11 @@ def compare_filenames(hash: str, db) -> list:
         # but, by coincidence, have the same length
         file_list.remove(file_list[0])
     else:
-        # Hashes are same but filenames are different
+        # Hashes are same but filenames are different, return an empty list
         warnings.warn(
             "The following filenames need investigation.\n- " + "\n- ".join(file_list)
         )
+        file_list = []
 
     return file_list
 


### PR DESCRIPTION
Return an empty list when the warning that some files should be investigated is raised. Otherwise, the whole file list is added to the list to be deleted. That is a bug.
